### PR TITLE
Take out python 3.8 and 3.9 from environment.yml and setup.py

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: oguk-calibrate-dev
 channels:
 - conda-forge
 dependencies:
-- python>=3.7.7
+- python==3.7.7
 - ipython
 - setuptools
 - mkl>=2020.2

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,6 @@ config = {
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     "tests_require": ["pytest"],


### PR DESCRIPTION
@jdebacker's current [PR #2](https://github.com/PSLmodels/OG-UK-Calibration/pull/2) to `PSLmodels/OG-UK-Calibration` currently fails the Build and test [Python 3.7] CI in the Setup Miniconda stage with the following error.
```
Error: The process '/usr/share/miniconda/condabin/conda' failed with exit code 1
```
My suspicion is that it is failing because the `environment.yml` allows for `python>=3.7.7` and `setup.py` allows for Python 3.8 and 3.9. We have to limit this repository to Python 3.7 currently because the `openfisca-uk` microsimulation model is only tested for Python 3.7.

This PR attempts to solve the Setup Miniconda error by setting the Python version only equal to `python==3.7.7` and removing Python 3.8 and 3.9 from `setup.py`. Let's see if this fixes the problem.